### PR TITLE
Produce smaller docker images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,14 +51,12 @@ dependencies = [
  "actix-utils",
  "base64",
  "bitflags",
- "brotli2",
  "bytes 0.5.6",
  "cookie",
  "copyless",
  "derive_more",
  "either",
  "encoding_rs",
- "flate2",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -395,26 +393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "brotli2"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
-dependencies = [
- "brotli-sys",
- "libc",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,12 +424,6 @@ checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
 dependencies = [
  "bytes 1.0.1",
 ]
-
-[[package]]
-name = "cc"
-version = "1.0.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -540,15 +512,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
-name = "crc32fast"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,18 +581,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
-dependencies = [
- "cfg-if 1.0.0",
- "crc32fast",
- "libc",
- "miniz_oxide",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,13 @@ lazy_static = "1.4.0"
 dotenv = "0.15"
 log = "0.4"
 env_logger = "0.8"
-clap = "3.0.0-beta.2"
+clap = { version = "3.0.0-beta.2", features = ["std"] }
 prometheus = "0.11"
-actix-web = "3"
+actix-web = { version = "3", default-features = false }
 actix-web-prom = "0.5"
 thiserror = "1.0"
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM rust:1.49 AS builder
 WORKDIR /usr/src/app
+RUN rustup target add x86_64-unknown-linux-musl
+RUN apt-get update && apt-get install --yes musl-tools
 COPY . .
-RUN cargo install --path .
+RUN cargo install --target x86_64-unknown-linux-musl --path .
+RUN strip /usr/local/cargo/bin/ngx-prom
 
-FROM ubuntu:20.04
-COPY --from=builder /usr/local/cargo/bin/ngx-prom /usr/local/bin/ngx-prom
-CMD ["ngx-prom"]
-
+FROM scratch
+COPY --from=builder /usr/local/cargo/bin/ngx-prom .
+CMD ["./ngx-prom"]

--- a/research/binary_size.md
+++ b/research/binary_size.md
@@ -1,0 +1,32 @@
+# Option use to reduce binary size
+
+default
+=> 11M
+
+opt = s
+=> 11M
+
+opt = 3, lto = fat
+=> 7.3M
+strip
+=> 4.3M
+
+opt = 3, lto = fat, codegen = 1
+=> 6.9M
+strip
+=> 4.6M
+
+opt = 3, lto = fat, codegen = 1, panic = abort
+=> 6.2M
+strip
+=> 4.2M
+
+opt = 3, lto = fat, codegen = 1, panic = abort + xargo
+=> 4.4M
+strip
+=> 3.8M
+
+opt = z, lto = fat, codegen = 1, panic = abort + xargo
+=> 4.0M
+strip
+=> 2.8M


### PR DESCRIPTION
From 85M to 4.6M

Changes:
- Use FROM scratch
- Enable lto
- Disable parallel build
- strip binary